### PR TITLE
When entering the ship terminal and going to the 'buyday' command and then exit the terminal

### DIFF
--- a/Anubis.LC.ExtraDays/Patches/TerminalPatch.cs
+++ b/Anubis.LC.ExtraDays/Patches/TerminalPatch.cs
@@ -1,0 +1,19 @@
+﻿using Anubis.LC.ExtraDays;
+using HarmonyLib;
+using LethalAPI.TerminalCommands.Models;
+using System.Collections.Generic;
+
+
+/// <summary>
+/// Patching Terminal
+/// </summary>
+[HarmonyPatch(typeof(Terminal))]
+internal static class TerminalPatch
+{
+    [HarmonyPatch("QuitTerminal")]
+    [HarmonyPostfix]
+    private static void QuitTerminal(Terminal __instance)
+    {
+        CommandHandler.HandleCommandInput("help", __instance);
+    }
+}


### PR DESCRIPTION
When the player enters the ship terminal
And player types `buyday` command
And  player in the ConfirmationInteraction
And exit the ship terminal
And the player enters the terminal again
And the player types anything
Then terminal should work as expected

Actual result:
Player sees 'Cancelled order'

This PR fix this

