### PR TITLE
When player that is not the host buying extra day - credits are not in sync

### DIFF
--- a/Anubis.LC.ExtraDays/Extensions/TerminalExtensions.cs
+++ b/Anubis.LC.ExtraDays/Extensions/TerminalExtensions.cs
@@ -8,11 +8,6 @@ namespace Anubis.LC.ExtraDays.Extensions
 {
     public static class TerminalExtensions
     {
-        public static void SetNewCredits(this Terminal terminal, int credits)
-        {
-            terminal.groupCredits = credits;
-        }
-
         public static bool IsExtraDaysPurchasable(this Terminal terminal)
         {
             return terminal.groupCredits >= TimeOfDay.Instance.GetExtraDaysPrice();
@@ -21,12 +16,10 @@ namespace Anubis.LC.ExtraDays.Extensions
         public static void SetDaysToDeadline(this Terminal terminal)
         {
             ExtraDaysToDeadlineStaticHelper.Logger.LogInfo($"Player input CONFIRM and {ExtraDaysToDeadlineStaticHelper.DAYS_TO_INCREASE} day to deadline has been added");
-            TimeOfDay.Instance.AddXDaysToDeadline(ExtraDaysToDeadlineStaticHelper.DAYS_TO_INCREASE);
-
             float creditsFormula = TimeOfDay.Instance.GetExtraDaysPrice();
-            int newCredits = terminal.groupCredits -= (int)creditsFormula;
-
-            terminal.SetNewCredits(newCredits);
+            terminal.groupCredits -= (int)creditsFormula;
+            terminal.SyncGroupCreditsServerRpc(terminal.groupCredits, terminal.numberOfItemsInDropship);
+            TimeOfDay.Instance.AddXDaysToDeadline(ExtraDaysToDeadlineStaticHelper.DAYS_TO_INCREASE);
         }
     }
 }

--- a/Anubis.LC.ExtraDays/Extensions/TimeOfDayExtensions.cs
+++ b/Anubis.LC.ExtraDays/Extensions/TimeOfDayExtensions.cs
@@ -70,7 +70,7 @@ namespace Anubis.LC.ExtraDays.Extensions
         {
             timeOfDay.SetDeadlineDaysAmount(tryGetFromDisk);
             timeOfDay.SetBuyingRateForDay();
-            StartOfRound.Instance.SyncCompanyBuyingRateClientRpc(StartOfRound.Instance.companyBuyingRate);
+            StartOfRound.Instance.SyncCompanyBuyingRateServerRpc();
             ExtraDaysToDeadlineStaticHelper.Logger.LogInfo("Buying rate recalculated");
         }
 


### PR DESCRIPTION
When a player who is not the host buys an extra day - credits are not in sync
+ Fixing another issue regarding the buying rate sync